### PR TITLE
Use os._exit so the main thread exits

### DIFF
--- a/goverge/coverage.py
+++ b/goverge/coverage.py
@@ -11,7 +11,7 @@ def check_failed(return_code):
     :param return_code: The return code of a test run
     """
     if return_code != 0:
-        exit(return_code)
+        os._exit(return_code)
 
 
 def generate_coverage(

--- a/goverge/test/test_coverage.py
+++ b/goverge/test/test_coverage.py
@@ -8,8 +8,11 @@ from goverge.coverage import get_package_deps
 
 
 class TestCheckFailed(unittest.TestCase):
-    def test_check_failed(self):
-        self.assertRaises(SystemExit, check_failed, [1])
+
+    @patch('goverge.coverage.os._exit')
+    def test_check_failed(self, mock_exit):
+        check_failed(1)
+        mock_exit.assert_called_with(1)
 
 
 @patch('goverge.coverage.get_package_deps')


### PR DESCRIPTION
The main thread wasn't exiting which means it wasn't causing the build to fail this makes it so that they build will fail.

@jacobmoss-wf 
