### PR TITLE
Remove integration flag and get test imports

### DIFF
--- a/goverge/main.py
+++ b/goverge/main.py
@@ -97,8 +97,7 @@ def goverge(options):
 
     generate_coverage(
         sub_dirs, project_package, project_root, options.godep, options.short,
-        options.xml, options.xml_dir, options.race, options.tag,
-        options.integration)
+        options.xml, options.xml_dir, options.race, options.tag)
 
     reports = get_coverage_reports("./reports")
 
@@ -136,17 +135,6 @@ def _parse_args(argv):
         default=False,
         help=(
             "View a html report of the coverage file that is generated."
-        )
-    )
-
-    p.add_argument(
-        '--integration',
-        action='store_true',
-        default=False,
-        help=(
-            "If running integration tests get the coverage for all local "
-            "packages, this is helpful since there isn't a way to get test "
-            "package dependencies."
         )
     )
 

--- a/goverge/test/test_coverage.py
+++ b/goverge/test/test_coverage.py
@@ -35,16 +35,16 @@ class TestCheckFailed(unittest.TestCase):
 class TestCoverage(unittest.TestCase):
 
     @patch('goverge.coverage.subprocess.call', return_value=0)
-    def test_generate_package_coverage_godep_short_race_int(
+    def test_generate_package_coverage_godep_short_race(
             self, mock_call, mock_deps):
         mock_deps.return_value = ["foo/bar", "foo/bar/baz", "."]
 
         generate_package_coverage(
             "test_path", "project_package", "test_package", "project_root",
-            True, True, False, "foo/", True, "foo", True)
+            True, True, False, "foo/", True, "foo")
 
         mock_deps.assert_called_once_with(
-            "project_package", "test_path", True)
+            "project_package", "test_path")
 
         mock_call.assert_called_once_with([
             "godep", "go", "test", "-v", '-covermode=set',
@@ -58,10 +58,10 @@ class TestCoverage(unittest.TestCase):
 
         generate_package_coverage(
             "test_path", "project_package", "test_package", "project_root",
-            False, False, False, "foo/", False, None, False)
+            False, False, False, "foo/", False, None)
 
         mock_deps.assert_called_once_with(
-            "project_package", "test_path", False)
+            "project_package", "test_path")
 
         mock_call.assert_called_once_with([
             "go", "test", "-v", '-covermode=set',
@@ -75,10 +75,10 @@ class TestCoverage(unittest.TestCase):
 
         generate_package_coverage(
             "test_path", "project_package", "test_package", "project_root",
-            False, False, True, "foo/", False, None, False)
+            False, False, True, "foo/", False, None)
 
         mock_deps.assert_called_once_with(
-            "project_package", "test_path", False)
+            "project_package", "test_path")
 
         mock_gen_xml.assert_called_once_with(
             "foo/test_package",
@@ -100,21 +100,9 @@ class TestPackageDeps(unittest.TestCase):
         mock_communicate.return_value = (
             '[foo/bar/a bar/baz foo/bar/b foo/bar/c]', '')
 
-        deps = get_package_deps("foo/bar", ".", False)
+        deps = get_package_deps("foo/bar", ".")
 
         mock_communicate.assert_called_once()
 
-        self.assertEquals(deps, ["foo/bar/a", "foo/bar/b", "foo/bar/c", "."])
-
-    @patch('goverge.coverage.subprocess.Popen')
-    @patch('goverge.coverage.subprocess.Popen.communicate')
-    def test_package_deps_int(self, mock_communicate, mock_popen):
-        mock_popen.return_value = Popen
-        mock_communicate.return_value = (
-            'foo/bar/a\nfoo/bar/b\nfoo/tests/c', '')
-
-        deps = get_package_deps("foo/bar", ".", True)
-
-        mock_communicate.assert_called_once()
-
-        self.assertEquals(deps, ["foo/bar/a", "foo/bar/b"])
+        self.assertEquals(
+            sorted(deps), sorted(["foo/bar/a", "foo/bar/b", "foo/bar/c", "."]))

--- a/goverge/test/test_main.py
+++ b/goverge/test/test_main.py
@@ -67,7 +67,7 @@ class GovergeTestCase(TestCase):
         assert mock_cwd.called
         gen_cov.assert_called_once_with(
             ['/foo/bar'], "github.com/Workiva/goverge", "/foo/bar", True, True,
-            False, 'xml_reports/', True, None, False)
+            False, 'xml_reports/', True, None)
         assert mock_comm.called
         mock_popen.assert_called_once_with(
             ["go", "tool", "cover", "--html=test_coverage.txt"],
@@ -80,7 +80,6 @@ class parse_argsTestCase(TestCase):
         expected = {
             'godep': True,
             'html': False,
-            'integration': False,
             'project_import': None,
             "race": False,
             'short': False,
@@ -96,7 +95,6 @@ class parse_argsTestCase(TestCase):
         expected = {
             'godep': False,
             'html': True,
-            'integration': False,
             'project_import': None,
             "race": False,
             'short': False,
@@ -107,28 +105,11 @@ class parse_argsTestCase(TestCase):
         }
         self.assertEquals(expected, vars(args))
 
-    def test_integration(self):
-        args = main._parse_args(['--integration'])
-        expected = {
-            'godep': False,
-            'html': False,
-            'integration': True,
-            'project_import': None,
-            "race": False,
-            'short': False,
-            'tag': None,
-            'test_path': None,
-            'xml': False,
-            'xml_dir': 'xml_reports/'
-        }
-        self.assertEqual(expected, vars(args))
-
     def test_short(self):
         args = main._parse_args(['--short'])
         expected = {
             'godep': False,
             'html': False,
-            'integration': False,
             'project_import': None,
             "race": False,
             'short': True,
@@ -144,7 +125,6 @@ class parse_argsTestCase(TestCase):
         expected = {
             'godep': False,
             'html': False,
-            'integration': False,
             'project_import': None,
             "race": False,
             'short': False,
@@ -163,7 +143,6 @@ class parse_argsTestCase(TestCase):
         expected = {
             'godep': False,
             'html': False,
-            'integration': False,
             'project_import': None,
             "race": False,
             'short': False,
@@ -181,7 +160,6 @@ class parse_argsTestCase(TestCase):
         expected = {
             'godep': False,
             'html': False,
-            'integration': False,
             'project_import': "github.com/Workiva/goverge",
             "race": False,
             'short': False,
@@ -197,7 +175,6 @@ class parse_argsTestCase(TestCase):
         expected = {
             'godep': False,
             'html': False,
-            'integration': False,
             'project_import': None,
             "race": False,
             'short': False,
@@ -213,7 +190,6 @@ class parse_argsTestCase(TestCase):
         expected = {
             'godep': False,
             'html': False,
-            'integration': False,
             'project_import': None,
             "race": False,
             'short': False,
@@ -229,7 +205,6 @@ class parse_argsTestCase(TestCase):
         expected = {
             'godep': False,
             'html': False,
-            'integration': False,
             'project_import': None,
             "race": True,
             'short': False,


### PR DESCRIPTION
This removes the -integration flag because that wasn't really working the way that I hoped it would this way works a bit better but doesn't get a quite complete picture of what it's covering unfortunately but it's better then no information.

@matthinrichsen-wf @jacobmoss-wf @alexandercampbell-wf 