### PR TITLE
Add threads and version flags

### DIFF
--- a/goverge/coverage.py
+++ b/goverge/coverage.py
@@ -54,7 +54,7 @@ def generate_coverage(
     :type tag: string
     :param tag: A custom build tag to use when running go test
     :type max_threads: int
-    :param max_threads: The number of threads for the tests to run on
+    :param max_threads: The maximum number of threads for the tests to run on
     """
 
     threads = []

--- a/goverge/coverage.py
+++ b/goverge/coverage.py
@@ -32,7 +32,7 @@ def check_failed(return_code):
 
 def generate_coverage(
         packages, project_package, project_root, godep, short, xml, xml_dir,
-        race, tag):
+        race, tag, max_threads):
     """ Generate the coverage for a list of packages.
 
     :type package: list
@@ -53,9 +53,10 @@ def generate_coverage(
     :param race: If the race flag should be used or not
     :type tag: string
     :param tag: A custom build tag to use when running go test
+    :type max_threads: int
+    :param max_threads: The number of threads for the tests to run on
     """
 
-    max_threads = 4
     threads = []
     while threads or packages:
 

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -129,7 +129,8 @@ def _parse_args(argv):
         '--version',
         action='version',
         version='goverge ' + version,
-    help=('Display the installed version'))
+        help=('Display the installed version')
+    )
 
     p.add_argument(
         '--godep',

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -23,6 +23,7 @@ from subprocess import Popen
 import sys
 
 
+from _pkg_meta import version
 from coverage import generate_coverage
 from reports import compile_reports
 from reports import get_coverage_reports
@@ -97,7 +98,8 @@ def goverge(options):
 
     generate_coverage(
         sub_dirs, project_package, project_root, options.godep, options.short,
-        options.xml, options.xml_dir, options.race, options.tag)
+        options.xml, options.xml_dir, options.race, options.tag,
+        int(options.threads))
 
     reports = get_coverage_reports("./reports")
 
@@ -122,6 +124,12 @@ def _parse_args(argv):
     """
 
     p = argparse.ArgumentParser(prog='goverge')
+
+    p.add_argument(
+        '--version',
+        action='version',
+        version='goverge ' + version)
+
     p.add_argument(
         '--godep',
         action='store_true',
@@ -182,6 +190,15 @@ def _parse_args(argv):
         help=(
             'Path(s) to a specific package to get the coverage on\n'
             'Example: --test_path path/one --test_path path/two'
+        )
+    )
+
+    p.add_argument(
+        '--threads',
+        action='store',
+        default=4,
+        help=(
+            "Number of threads to use when running tests."
         )
     )
 

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -128,7 +128,8 @@ def _parse_args(argv):
     p.add_argument(
         '--version',
         action='version',
-        version='goverge ' + version)
+        version='goverge ' + version,
+    help=('Display the installed version'))
 
     p.add_argument(
         '--godep',
@@ -198,7 +199,7 @@ def _parse_args(argv):
         action='store',
         default=4,
         help=(
-            "Number of threads to use when running tests."
+            "The Maximum number of threads to use when running tests."
         )
     )
 

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -129,32 +129,28 @@ def _parse_args(argv):
         '--version',
         action='version',
         version='goverge ' + version,
-        help=('Display the installed version')
+        help='Display the installed version'
     )
 
     p.add_argument(
         '--godep',
         action='store_true',
         default=False,
-        help=(
-            'Run coverage using the projects godep files.'))
+        help='Run coverage using the projects godep files.'
+        )
 
     p.add_argument(
         '--html',
         action='store_true',
         default=False,
-        help=(
-            "View a html report of the coverage file that is generated."
-        )
+        help="View a html report of the coverage file that is generated."
     )
 
     p.add_argument(
         '--race',
         action='store_true',
         default=False,
-        help=(
-            "Run tests using the -race flag"
-        )
+        help="Run tests using the -race flag"
     )
 
     p.add_argument(
@@ -172,17 +168,13 @@ def _parse_args(argv):
         '--short',
         action='store_true',
         default=False,
-        help=(
-            'Run coverage using the -short flag'
-        )
+        help='Run coverage using the -short flag'
     )
 
     p.add_argument(
         '--tag',
         action='store',
-        help=(
-            "Use an optional build tag when running tests."
-        )
+        help="Use an optional build tag when running tests."
     )
 
     p.add_argument(
@@ -199,9 +191,7 @@ def _parse_args(argv):
         '--threads',
         action='store',
         default=4,
-        help=(
-            "The Maximum number of threads to use when running tests."
-        )
+        help='The Maximum number of threads to use when running tests.'
     )
 
     p.add_argument(
@@ -218,9 +208,7 @@ def _parse_args(argv):
         '--xml_dir',
         action='store',
         default="xml_reports/",
-        help=(
-            "The location to put the xml reports that are generated."
-        )
+        help="The location to put the xml reports that are generated."
     )
 
     return p.parse_args(argv)

--- a/goverge/test/test_main.py
+++ b/goverge/test/test_main.py
@@ -226,16 +226,4 @@ class parse_argsTestCase(TestCase):
 
     def test_threads(self):
         args = main._parse_args(["--threads=10"])
-        expected = {
-            'godep': False,
-            'html': False,
-            'project_import': None,
-            "race": False,
-            'short': False,
-            'tag': None,
-            'test_path': None,
-            'threads': '10',
-            'xml': False,
-            'xml_dir': 'xml_reports/'
-        }
-        self.assertEquals(expected, vars(args))
+        self.assertEquals('10', vars(args).get('threads'))

--- a/goverge/test/test_main.py
+++ b/goverge/test/test_main.py
@@ -67,7 +67,7 @@ class GovergeTestCase(TestCase):
         assert mock_cwd.called
         gen_cov.assert_called_once_with(
             ['/foo/bar'], "github.com/Workiva/goverge", "/foo/bar", True, True,
-            False, 'xml_reports/', True, None)
+            False, 'xml_reports/', True, None, 4)
         assert mock_comm.called
         mock_popen.assert_called_once_with(
             ["go", "tool", "cover", "--html=test_coverage.txt"],
@@ -85,6 +85,7 @@ class parse_argsTestCase(TestCase):
             'short': False,
             'tag': None,
             'test_path': None,
+            'threads': 4,
             'xml': False,
             'xml_dir': 'xml_reports/'
         }
@@ -100,6 +101,7 @@ class parse_argsTestCase(TestCase):
             'short': False,
             'tag': None,
             'test_path': None,
+            'threads': 4,
             'xml': False,
             'xml_dir': 'xml_reports/'
         }
@@ -115,6 +117,7 @@ class parse_argsTestCase(TestCase):
             'short': True,
             'tag': None,
             'test_path': None,
+            'threads': 4,
             'xml': False,
             'xml_dir': 'xml_reports/'
         }
@@ -130,6 +133,7 @@ class parse_argsTestCase(TestCase):
             'short': False,
             'tag': "foo",
             'test_path': None,
+            'threads': 4,
             'xml': False,
             'xml_dir': 'xml_reports/'
         }
@@ -148,6 +152,7 @@ class parse_argsTestCase(TestCase):
             'short': False,
             'tag': None,
             'test_path': ['/foo/bar', '/bar/foo'],
+            'threads': 4,
             'xml': False,
             'xml_dir': 'xml_reports/'
         }
@@ -165,6 +170,7 @@ class parse_argsTestCase(TestCase):
             'short': False,
             'tag': None,
             'test_path': None,
+            'threads': 4,
             'xml': False,
             'xml_dir': 'xml_reports/'
         }
@@ -180,6 +186,7 @@ class parse_argsTestCase(TestCase):
             'short': False,
             'tag': None,
             'test_path': None,
+            'threads': 4,
             'xml': True,
             'xml_dir': 'xml_reports/'
         }
@@ -195,6 +202,7 @@ class parse_argsTestCase(TestCase):
             'short': False,
             'tag': None,
             'test_path': None,
+            'threads': 4,
             'xml': False,
             'xml_dir': '/foo/bar/'
         }
@@ -210,6 +218,23 @@ class parse_argsTestCase(TestCase):
             'short': False,
             'tag': None,
             'test_path': None,
+            'threads': 4,
+            'xml': False,
+            'xml_dir': 'xml_reports/'
+        }
+        self.assertEquals(expected, vars(args))
+
+    def test_threads(self):
+        args = main._parse_args(["--threads=10"])
+        expected = {
+            'godep': False,
+            'html': False,
+            'project_import': None,
+            "race": False,
+            'short': False,
+            'tag': None,
+            'test_path': None,
+            'threads': '10',
             'xml': False,
             'xml_dir': 'xml_reports/'
         }


### PR DESCRIPTION
- Add the ability to get the version of the application
- Add the ability to specify the number of threads for the tests to run on

This addresses https://github.com/Workiva/goverge/issues/15 and https://github.com/Workiva/goverge/issues/14

@markcampanelli-wf for https://github.com/Workiva/goverge/issues/14 just run with --threads=1 and it should run in basically "serial" mode.

Please review: @markcampanelli-wf @jacobmoss-wf @aldenpeterson-wf @seangerhardt-wf @matthinrichsen-wf  