### PR TITLE
Fix issues with tag flag

### DIFF
--- a/goverge/coverage.py
+++ b/goverge/coverage.py
@@ -113,7 +113,7 @@ def generate_package_coverage(
     """
 
     # Get the dependencies of the package we are testing
-    package_deps = get_package_deps(project_package, test_path)
+    package_deps = get_package_deps(project_package, test_path, tag)
 
     options = [
         "go", "test", '-covermode=count',
@@ -131,7 +131,7 @@ def generate_package_coverage(
         options.append("-race")
 
     if tag:
-        options.append("-tags {}".format(tag))
+        options.append("-tags={}".format(tag))
 
     if xml:
         return generate_xml(xml_dir + test_package, options, test_path)
@@ -169,23 +169,27 @@ def generate_xml(output_loc, options, test_path):
     check_failed(p.returncode)
 
 
-def get_package_deps(project_package, test_path):
+def get_package_deps(project_package, test_path, tag):
     """ Gets the packages dependencies that are part of the project.
 
     :type project_package: string
     :param project_package: The base package of the project
     :type test_path: string
     :param test_path: The path of the package that is under test
+    :type tag: string
+    :param tag: A custom build tag to use when running go test
     :rtype: list
     :return: Project dependencies
     """
 
     output, _ = subprocess.Popen(
-        ["go", "list", "-f", "'{{.Deps}}'"],
+        ["go", "list", "-f", "'{{.Deps}}'",
+         "-tags={}".format(tag) if tag else ""],
         stdout=subprocess.PIPE, cwd=test_path).communicate()
 
     test_output, _ = subprocess.Popen(
-        ["go", "list", "-f", "'{{.TestImports}}'"],
+        ["go", "list", "-f", "'{{.TestImports}}'",
+         "-tags={}".format(tag) if tag else ""],
         stdout=subprocess.PIPE, cwd=test_path).communicate()
 
     output = test_output.split() + output.split()

--- a/goverge/test/test_coverage.py
+++ b/goverge/test/test_coverage.py
@@ -44,12 +44,12 @@ class TestCoverage(unittest.TestCase):
             True, True, False, "foo/", True, "foo")
 
         mock_deps.assert_called_once_with(
-            "project_package", "test_path")
+            "project_package", "test_path", "foo")
 
         mock_call.assert_called_once_with([
             "godep", "go", "test", '-covermode=count',
             u"-coverprofile=project_root/reports/test_package.txt",
-            u"-coverpkg=foo/bar,foo/bar/baz,.", "-short", "-race", "-tags foo"
+            u"-coverpkg=foo/bar,foo/bar/baz,.", "-short", "-race", "-tags=foo"
         ], cwd="test_path")
 
     @patch('goverge.coverage.subprocess.call', return_value=0)
@@ -61,7 +61,7 @@ class TestCoverage(unittest.TestCase):
             False, False, False, "foo/", False, None)
 
         mock_deps.assert_called_once_with(
-            "project_package", "test_path")
+            "project_package", "test_path", None)
 
         mock_call.assert_called_once_with([
             "go", "test", '-covermode=count',
@@ -78,7 +78,7 @@ class TestCoverage(unittest.TestCase):
             False, False, True, "foo/", False, None)
 
         mock_deps.assert_called_once_with(
-            "project_package", "test_path")
+            "project_package", "test_path", None)
 
         mock_gen_xml.assert_called_once_with(
             "foo/test_package",
@@ -98,9 +98,9 @@ class TestPackageDeps(unittest.TestCase):
     def test_package_deps(self, mock_communicate, mock_popen):
         mock_popen.return_value = Popen
         mock_communicate.return_value = (
-            '[foo/bar/a bar/baz foo/bar/b foo/bar/c]', '')
+            '[foo/bar/a bar/baz foo/bar/b foo/bar/c]', None)
 
-        deps = get_package_deps("foo/bar", ".")
+        deps = get_package_deps("foo/bar", ".", "foo")
 
         mock_communicate.assert_called_once()
 


### PR DESCRIPTION
Tags flag was hitting flag provided but not defined error because it was
missing the =

Fix an issue where the package deps without the tags
were hitting a "no buildable Go source files" error when the files with
the tags were then only buildable files.

@brettonfinch-wf @jacobmoss-wf @alexandercampbell-wf @matthinrichsen-wf @seanstrickland-wf @aldenpeterson-wf 