### PR TITLE
Ignore the vendor folder

### DIFF
--- a/goverge/main.py
+++ b/goverge/main.py
@@ -92,9 +92,10 @@ def goverge(options):
         sub_dirs = options.test_path
 
     else:
-        sub_dirs = [x[0] for x in os.walk(project_root)
-                    if "/." not in x[0] and "Godeps" not in x[0] and
-                    "vendor" not in x[0]]
+        sub_dirs = [
+            x[0] for x in os.walk(project_root)
+            if x[0] not in ["/.", "Godeps", "vendor"]
+            ]
 
     generate_coverage(
         sub_dirs, project_package, project_root, options.godep, options.short,

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -93,7 +93,8 @@ def goverge(options):
 
     else:
         sub_dirs = [x[0] for x in os.walk(project_root)
-                    if "/." not in x[0] and "Godeps" not in x[0]]
+                    if "/." not in x[0] and "Godeps" not in x[0] and
+                    "vendor" not in x[0]]
 
     generate_coverage(
         sub_dirs, project_package, project_root, options.godep, options.short,


### PR DESCRIPTION
The new way go does vendoring it puts everything in a vendor folder we don't want to be getting coverage on that folder since the idea isn't that we get coverage for outside dependencies just for the project itself.

@jacobmoss-wf @aldenpeterson-wf @seangerhardt-wf 