### PR TITLE
Fix getting test packages so it doesn't get Godeps

### DIFF
--- a/goverge/main.py
+++ b/goverge/main.py
@@ -58,6 +58,19 @@ def get_project_package(project_root, project_import):
     return project_import.replace("'", "")
 
 
+def get_test_packages(project_root):
+    """
+    :type project_root: string
+    :param project_root: The location of the project root
+    :rtype: List
+    :return: The list of to run coverage on
+    """
+    return [
+        x[0] for x in os.walk(project_root)
+        if not any(word in x[0] for word in ["/.", "Godeps", "vendor"])
+        ]
+
+
 def main():
     """Main entry point into goverge."""
 
@@ -92,10 +105,7 @@ def goverge(options):
         sub_dirs = options.test_path
 
     else:
-        sub_dirs = [
-            x[0] for x in os.walk(project_root)
-            if x[0] not in ["/.", "Godeps", "vendor"]
-            ]
+        get_test_packages(project_root)
 
     generate_coverage(
         sub_dirs, project_package, project_root, options.godep, options.short,

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -60,10 +60,11 @@ def get_project_package(project_root, project_import):
 
 def get_test_packages(project_root):
     """
+    Get the list of packages in the project
     :type project_root: string
     :param project_root: The location of the project root
     :rtype: List
-    :return: The list of to run coverage on
+    :return: The list of packages to run coverage on
     """
     return [
         x[0] for x in os.walk(project_root)

--- a/goverge/test/test_main.py
+++ b/goverge/test/test_main.py
@@ -24,6 +24,22 @@ from unittest import TestCase
 from goverge import main
 
 
+class TestPackageTestCase(TestCase):
+
+    @patch('goverge.main.os.walk')
+    def test_get_test_packages(self, mock_os_walk):
+        mock_os_walk.return_value = [
+            ("/Godeps/_workspace/src/foo/", ('',), ("foo")),
+            ("/vendor/foo/", ('',), ("foo")),
+            ("/./foo", ('',), ("foo")),
+            ("/foo/bar", ('',), ("foo"))
+        ]
+
+        test_packages = main.get_test_packages("/foo/bar")
+        self.assertEqual(test_packages, ["/foo/bar"])
+        mock_os_walk.assert_called_once_with("/foo/bar")
+
+
 class MainTestCase(TestCase):
 
     @patch('goverge.main.goverge')


### PR DESCRIPTION
Was a bug in getting the packages to run coverage on where it wasn't actually skipping things like godeps this fixes the issue and adds a test around it.

@tomdeering-wf @tylerrinnan-wf @seangerhardt-wf @jacobmoss-wf 