### PR TITLE
Ignore vendor folder when getting dependencies and update version

### DIFF
--- a/goverge/_pkg_meta.py
+++ b/goverge/_pkg_meta.py
@@ -1,2 +1,2 @@
-version_info = (0, 0, 18)
+version_info = (0, 0, 19)
 version = '.'.join(map(str, version_info))

--- a/goverge/coverage.py
+++ b/goverge/coverage.py
@@ -205,7 +205,8 @@ def get_package_deps(project_package, test_path, tag):
     package_deps = [
         package.replace("]", "").replace("[", "").replace("'", "")
         for package in list(set(output))
-        if project_package.split("\n")[0] in package]
+        if project_package.split("\n")[0] in package and
+        project_package.split("\n")[0]+"/vendor" not in package]
 
     package_deps.append(".")
 

--- a/goverge/coverage.py
+++ b/goverge/coverage.py
@@ -201,12 +201,12 @@ def get_package_deps(project_package, test_path, tag):
         stdout=subprocess.PIPE, cwd=test_path).communicate()
 
     output = test_output.split() + output.split()
-
-    package_deps = [
-        package.replace("]", "").replace("[", "").replace("'", "")
-        for package in list(set(output))
-        if project_package.split("\n")[0] in package and
-        project_package.split("\n")[0]+"/vendor" not in package]
+    project_path = project_package.split("\n")[0]
+    package_deps = []
+    for package in list(set(output)):
+        if project_path in package and project_path + "/vendor" not in package:
+            p = package.replace("]", "").replace("[", "").replace("'", "")
+            package_deps.append(p)
 
     package_deps.append(".")
 

--- a/goverge/coverage.py
+++ b/goverge/coverage.py
@@ -204,7 +204,9 @@ def get_package_deps(project_package, test_path, tag):
     project_path = project_package.split("\n")[0]
     package_deps = []
     for package in list(set(output)):
-        if project_path in package and project_path + "/vendor" not in package:
+        # Check that the dependency is part of the local project under test and
+        # not part of the vendor dependencies
+        if project_path + "/vendor" not in package and project_path in package:
             p = package.replace("]", "").replace("[", "").replace("'", "")
             package_deps.append(p)
 

--- a/goverge/test/test_coverage.py
+++ b/goverge/test/test_coverage.py
@@ -99,7 +99,7 @@ class TestPackageDeps(unittest.TestCase):
     def test_package_deps(self, mock_communicate, mock_popen):
         mock_popen.return_value = Popen
         mock_communicate.return_value = (
-            '[foo/bar/a bar/baz foo/bar/b foo/bar/c]', None)
+            '[foo/bar/a bar/baz foo/bar/b foo/bar/c foo/bar/vendor/baz]', None)
 
         deps = get_package_deps("foo/bar", ".", "foo")
 


### PR DESCRIPTION
This ignores the vendor folder when getting dependencies since we don't want to get the coverage for our dependencies just the repo under test.

@charliestrawn-wf @aldenpeterson-wf @seangerhardt-wf 