### PR TITLE
Add option to ignore folders

### DIFF
--- a/goverge/coverage.py
+++ b/goverge/coverage.py
@@ -32,7 +32,7 @@ def check_failed(return_code):
 
 def generate_coverage(
         packages, project_package, project_root, godep, short, xml, xml_dir,
-        race, tag, max_threads, go_flags, ignore):
+        race, tag, max_threads, go_flags):
     """ Generate the coverage for a list of packages.
 
     :type packages: list
@@ -57,8 +57,6 @@ def generate_coverage(
     :param max_threads: The maximum number of threads for the tests to run on
     :type go_flags: list
     :param go_flags: list of go build flags to use when running tests
-    :type ignore: list
-    :param ignore: list of directories to skip coverage
     """
 
     threads = []
@@ -83,7 +81,6 @@ def generate_coverage(
                 race,
                 tag,
                 go_flags,
-                ignore,
             ))
             t.daemon = True
             t.start()
@@ -95,7 +92,7 @@ def generate_coverage(
 
 def generate_package_coverage(
         test_path, project_package, test_package, project_root, godep, short,
-        xml, xml_dir, race, tag, go_flags, ignore):
+        xml, xml_dir, race, tag, go_flags):
     """ Generates the coverage report for a package.
 
     :type test_path: string
@@ -118,8 +115,6 @@ def generate_package_coverage(
     :param tag: A custom build tag to use when running go test
     :type go_flags: list
     :param go_flags: list of go build flags to use when running tests
-    :type ignore: list
-    :param ignore: list of directories to skip coverage
     """
 
     # Get the dependencies of the package we are testing

--- a/goverge/coverage.py
+++ b/goverge/coverage.py
@@ -32,11 +32,11 @@ def check_failed(return_code):
 
 def generate_coverage(
         packages, project_package, project_root, godep, short, xml, xml_dir,
-        race, tag, max_threads, go_flags):
+        race, tag, max_threads, go_flags, ignore):
     """ Generate the coverage for a list of packages.
 
-    :type package: list
-    :param package: Packages to generate coverage for
+    :type packages: list
+    :param packages: Packages to generate coverage for
     :type project_package: string
     :param project_package: The package name of the base of the package
     :type project_root: string
@@ -57,6 +57,8 @@ def generate_coverage(
     :param max_threads: The maximum number of threads for the tests to run on
     :type go_flags: list
     :param go_flags: list of go build flags to use when running tests
+    :type ignore: list
+    :param ignore: list of directories to skip coverage
     """
 
     threads = []
@@ -81,6 +83,7 @@ def generate_coverage(
                 race,
                 tag,
                 go_flags,
+                ignore,
             ))
             t.daemon = True
             t.start()
@@ -92,7 +95,7 @@ def generate_coverage(
 
 def generate_package_coverage(
         test_path, project_package, test_package, project_root, godep, short,
-        xml, xml_dir, race, tag, go_flags):
+        xml, xml_dir, race, tag, go_flags, ignore):
     """ Generates the coverage report for a package.
 
     :type test_path: string
@@ -115,6 +118,8 @@ def generate_package_coverage(
     :param tag: A custom build tag to use when running go test
     :type go_flags: list
     :param go_flags: list of go build flags to use when running tests
+    :type ignore: list
+    :param ignore: list of directories to skip coverage
     """
 
     # Get the dependencies of the package we are testing

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -74,7 +74,6 @@ def get_test_packages(project_root, ignore):
     directories = [project_root]
     for root, subdirs, files in os.walk(project_root):
         for name in subdirs:
-            print "DIR: " + str(os.path.join(root, name))
             full_path = os.path.join(root, name)
             if str(os.path.join(root, name)).startswith(project_root) and full_path not in ignores and \
                             name not in ignores and full_path != project_root:

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -75,7 +75,7 @@ def get_test_packages(project_root, ignore):
     for root, subdirs, files in os.walk(project_root):
         for name in subdirs:
             full_path = os.path.join(root, name)
-            if str(os.path.join(root, name)).startswith(project_root) and full_path not in ignores and \
+            if str(full_path).startswith(project_root) and full_path not in ignores and \
                     name not in ignores and full_path != project_root:
                 directories.append(os.path.join(root, name))
     return directories

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -76,7 +76,7 @@ def get_test_packages(project_root, ignore):
         for name in subdirs:
             full_path = os.path.join(root, name)
             if str(os.path.join(root, name)).startswith(project_root) and full_path not in ignores and \
-                            name not in ignores and full_path != project_root:
+                    name not in ignores and full_path != project_root:
                 directories.append(os.path.join(root, name))
     return directories
 

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -71,13 +71,11 @@ def get_test_packages(project_root, ignore):
     ignores = ["/.", "Godeps", "vendor"]
     if ignore is not None:
         ignores.extend(ignore)
-    directories = [project_root]
-    for root, subdirs, files in os.walk(project_root):
-        for subdir in subdirs:
-            full_path = os.path.join(root, subdir)
-            if str(full_path).startswith(project_root) and full_path not in ignores and \
-                    subdir not in ignores and full_path != project_root:
-                directories.append(os.path.join(root, subdir))
+    directories = []
+    for root, subdirs, file in os.walk(project_root):
+        if not any(subdir in root for subdir in ignores):
+            directories.append(root)
+
     return directories
 
 
@@ -120,7 +118,7 @@ def goverge(options):
     generate_coverage(
         sub_dirs, project_package, project_root, options.godep, options.short,
         options.xml, options.xml_dir, options.race, options.tag,
-        int(options.threads), options.go_flags, options.ignore)
+        int(options.threads), options.go_flags)
 
     reports = get_coverage_reports("./reports")
 

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -73,11 +73,11 @@ def get_test_packages(project_root, ignore):
         ignores.extend(ignore)
     directories = [project_root]
     for root, subdirs, files in os.walk(project_root):
-        for name in subdirs:
-            full_path = os.path.join(root, name)
+        for subdir in subdirs:
+            full_path = os.path.join(root, subdir)
             if str(full_path).startswith(project_root) and full_path not in ignores and \
-                    name not in ignores and full_path != project_root:
-                directories.append(os.path.join(root, name))
+                    subdir not in ignores and full_path != project_root:
+                directories.append(os.path.join(root, subdir))
     return directories
 
 

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -75,10 +75,10 @@ def get_test_packages(project_root, ignore):
     for root, subdirs, files in os.walk(project_root):
         for name in subdirs:
             print "DIR: " + str(os.path.join(root, name))
-            if str(os.path.join(root, name)).startswith(project_root) and name not in ignores and os.path.join(root, name) != project_root:
-                print "ACCEPTED DIR" + str(os.path.join(root, name))
+            full_path = os.path.join(root, name)
+            if str(os.path.join(root, name)).startswith(project_root) and full_path not in ignores and \
+                            name not in ignores and full_path != project_root:
                 directories.append(os.path.join(root, name))
-    print "RETURNING: " + str(directories)
     return directories
 
 

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -72,7 +72,7 @@ def get_test_packages(project_root, ignore):
     if ignore is not None:
         ignores.extend(ignore)
     directories = []
-    for root, subdirs, file in os.walk(project_root):
+    for root, subdirs, file_names in os.walk(project_root):
         if not any(subdir in root for subdir in ignores):
             directories.append(root)
 

--- a/goverge/test/test_coverage.py
+++ b/goverge/test/test_coverage.py
@@ -41,7 +41,7 @@ class TestCoverage(unittest.TestCase):
 
         generate_package_coverage(
             "test_path", "project_package", "test_package", "project_root",
-            True, True, False, "foo/", True, "foo", ["-x", "-timeout=5m"])
+            True, True, False, "foo/", True, "foo", ["-x", "-timeout=5m"], [])
 
         mock_deps.assert_called_once_with(
             "project_package", "test_path", "foo")
@@ -59,7 +59,7 @@ class TestCoverage(unittest.TestCase):
 
         generate_package_coverage(
             "test_path", "project_package", "test_package", "project_root",
-            False, False, False, "foo/", False, None, None)
+            False, False, False, "foo/", False, None, None, None)
 
         mock_deps.assert_called_once_with(
             "project_package", "test_path", None)
@@ -76,7 +76,7 @@ class TestCoverage(unittest.TestCase):
 
         generate_package_coverage(
             "test_path", "project_package", "test_package", "project_root",
-            False, False, True, "foo/", False, None, None)
+            False, False, True, "foo/", False, None, None, None)
 
         mock_deps.assert_called_once_with(
             "project_package", "test_path", None)

--- a/goverge/test/test_coverage.py
+++ b/goverge/test/test_coverage.py
@@ -41,7 +41,7 @@ class TestCoverage(unittest.TestCase):
 
         generate_package_coverage(
             "test_path", "project_package", "test_package", "project_root",
-            True, True, False, "foo/", True, "foo", ["-x", "-timeout=5m"], [])
+            True, True, False, "foo/", True, "foo", ["-x", "-timeout=5m"])
 
         mock_deps.assert_called_once_with(
             "project_package", "test_path", "foo")
@@ -59,7 +59,7 @@ class TestCoverage(unittest.TestCase):
 
         generate_package_coverage(
             "test_path", "project_package", "test_package", "project_root",
-            False, False, False, "foo/", False, None, None, None)
+            False, False, False, "foo/", False, None, None)
 
         mock_deps.assert_called_once_with(
             "project_package", "test_path", None)
@@ -76,7 +76,7 @@ class TestCoverage(unittest.TestCase):
 
         generate_package_coverage(
             "test_path", "project_package", "test_package", "project_root",
-            False, False, True, "foo/", False, None, None, None)
+            False, False, True, "foo/", False, None, None)
 
         mock_deps.assert_called_once_with(
             "project_package", "test_path", None)

--- a/goverge/test/test_main.py
+++ b/goverge/test/test_main.py
@@ -33,12 +33,13 @@ class TestPackageTestCase(TestCase):
             ("/vendor/foo/", ('',), ("foo")),
             ("/./foo", ('',), ("foo")),
             ("/foo/bar/", ('',), ("foo")),
+            ("/foo/bar/baz", ('',), ("foo")),
             ("/foo/bar/ignore", ('',), ("foo"))
         ]
 
         test_packages = main.get_test_packages(project_root="/foo/bar/",
                                                ignore=["/foo/bar/ignore/"])
-        self.assertEqual(test_packages, ["/foo/bar/"])
+        self.assertEqual(test_packages, ["/foo/bar/", "/foo/bar/baz/"])
         mock_os_walk.assert_called_once_with("/foo/bar/")
 
 

--- a/goverge/test/test_main.py
+++ b/goverge/test/test_main.py
@@ -32,10 +32,11 @@ class TestPackageTestCase(TestCase):
             ("/Godeps/_workspace/src/foo/", ('',), ("foo")),
             ("/vendor/foo/", ('',), ("foo")),
             ("/./foo", ('',), ("foo")),
-            ("/foo/bar/", ('',), ("foo"))
+            ("/foo/bar/", ('',), ("foo")),
+            ("/foo/bar/ignore", ('',), ("foo"))
         ]
 
-        test_packages = main.get_test_packages("/foo/bar/", None)
+        test_packages = main.get_test_packages(project_root="/foo/bar/", ignore=["/foo/bar/ignore/"])
         self.assertEqual(test_packages, ["/foo/bar/"])
         mock_os_walk.assert_called_once_with("/foo/bar/")
 

--- a/goverge/test/test_main.py
+++ b/goverge/test/test_main.py
@@ -36,7 +36,8 @@ class TestPackageTestCase(TestCase):
             ("/foo/bar/ignore", ('',), ("foo"))
         ]
 
-        test_packages = main.get_test_packages(project_root="/foo/bar/", ignore=["/foo/bar/ignore/"])
+        test_packages = main.get_test_packages(project_root="/foo/bar/",
+                                               ignore=["/foo/bar/ignore/"])
         self.assertEqual(test_packages, ["/foo/bar/"])
         mock_os_walk.assert_called_once_with("/foo/bar/")
 

--- a/goverge/test/test_main.py
+++ b/goverge/test/test_main.py
@@ -86,7 +86,7 @@ class GovergeTestCase(TestCase):
         assert mock_cwd.called
         gen_cov.assert_called_once_with(
             ['/foo/bar'], "github.com/Workiva/goverge", "/foo/bar", True, True,
-            False, '/foo/bar/xml_reports/', True, None, 4, None, None)
+            False, '/foo/bar/xml_reports/', True, None, 4, None)
         assert mock_comm.called
         mock_popen.assert_called_once_with(
             ["go", "tool", "cover", "--html=test_coverage.txt"],

--- a/goverge/test/test_main.py
+++ b/goverge/test/test_main.py
@@ -32,12 +32,12 @@ class TestPackageTestCase(TestCase):
             ("/Godeps/_workspace/src/foo/", ('',), ("foo")),
             ("/vendor/foo/", ('',), ("foo")),
             ("/./foo", ('',), ("foo")),
-            ("/foo/bar", ('',), ("foo"))
+            ("/foo/bar/", ('',), ("foo"))
         ]
 
-        test_packages = main.get_test_packages("/foo/bar")
-        self.assertEqual(test_packages, ["/foo/bar"])
-        mock_os_walk.assert_called_once_with("/foo/bar")
+        test_packages = main.get_test_packages("/foo/bar/", None)
+        self.assertEqual(test_packages, ["/foo/bar/"])
+        mock_os_walk.assert_called_once_with("/foo/bar/")
 
 
 class MainTestCase(TestCase):
@@ -83,7 +83,7 @@ class GovergeTestCase(TestCase):
         assert mock_cwd.called
         gen_cov.assert_called_once_with(
             ['/foo/bar'], "github.com/Workiva/goverge", "/foo/bar", True, True,
-            False, '/foo/bar/xml_reports/', True, None, 4, None)
+            False, '/foo/bar/xml_reports/', True, None, 4, None, None)
         assert mock_comm.called
         mock_popen.assert_called_once_with(
             ["go", "tool", "cover", "--html=test_coverage.txt"],
@@ -105,7 +105,8 @@ class parse_argsTestCase(TestCase):
             'test_path': None,
             'threads': 4,
             'xml': False,
-            'xml_dir': '/foo/bar/xml_reports/'
+            'xml_dir': '/foo/bar/xml_reports/',
+            'ignore': None
         }
         self.assertEqual(expected, vars(args))
 

--- a/goverge/test/test_main.py
+++ b/goverge/test/test_main.py
@@ -29,17 +29,17 @@ class TestPackageTestCase(TestCase):
     @patch('goverge.main.os.walk')
     def test_get_test_packages(self, mock_os_walk):
         mock_os_walk.return_value = [
-            ("/Godeps/_workspace/src/foo/", ('',), ("foo")),
-            ("/vendor/foo/", ('',), ("foo")),
+            ("/foo/bar/Godeps", ('',), ("foo")),
+            ("/foo/bar/vendor/", ('',), ("foo")),
             ("/./foo", ('',), ("foo")),
             ("/foo/bar/", ('',), ("foo")),
             ("/foo/bar/baz", ('',), ("foo")),
-            ("/foo/bar/ignore", ('',), ("foo"))
+            ("/foo/bar/ignore", ('',), ("foo")),
         ]
 
         test_packages = main.get_test_packages(project_root="/foo/bar/",
-                                               ignore=["/foo/bar/ignore/"])
-        self.assertEqual(test_packages, ["/foo/bar/", "/foo/bar/baz/"])
+                                               ignore=["/foo/bar/ignore"])
+        self.assertEqual(test_packages, ["/foo/bar/", "/foo/bar/baz"])
         mock_os_walk.assert_called_once_with("/foo/bar/")
 
 


### PR DESCRIPTION
## Problem: 
Not all directories in a project may be considered of interest to collect coverage on - e.g. a directory that is archived and "inactive", but kept for historical viewing / convenience purposes.

## Solution:
Add an option to ignore directories to collect coverage on.

## Testing:
Updated tests. Also smoked tested locally using the dir name running goverge in the same directory, and also using the full path name of a folder to ignore.
@wesleybalvanz-wf @matthinrichsen-wf @travissmith-wf 