### PR TITLE
CM-311 Add Dockerfile that records dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ RUN pip install -r requirements_dev.txt
 
 # Audit
 RUN mkdir /audit/
-RUN pip freeze | tee /audit/pip.lock
+RUN pip freeze > /audit/pip.lock
 
 FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,4 @@ RUN pip install -r requirements_dev.txt
 RUN mkdir /audit/
 RUN pip freeze | tee /audit/pip.lock
 
+FROM scratch

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:2.7.14-alpine3.7 as build
+
+ARG BUILD_ARTIFACTS_AUDIT=/audit/*
+
+COPY ./requirements*.txt ./
+
+# Install requirements
+RUN pip install -r requirements_dev.txt
+
+# Audit
+RUN mkdir /audit/
+RUN pip freeze | tee /audit/pip.lock
+


### PR DESCRIPTION
Tests already run inside of travis-ci and people outside of the workvia org can't access smithy anyways so I only setup the dependency audit inside of smithy and left all the testing inside of travis-ci.

@Workiva/cm-tooling 