### PR TITLE
Support python3 and python2

### DIFF
--- a/goverge/main.py
+++ b/goverge/main.py
@@ -13,8 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-
-"""Entry points for goverge."""
 from __future__ import absolute_import
 
 import argparse
@@ -30,6 +28,7 @@ from .reports import compile_reports
 from .reports import get_coverage_reports
 
 
+"""Entry points for goverge."""
 def delete_folder(folder):
     """Delete a folder using the given path, ignoring OSErrors"""
     try:

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -29,6 +29,8 @@ from .reports import get_coverage_reports
 
 
 """Entry points for goverge."""
+
+
 def delete_folder(folder):
     """Delete a folder using the given path, ignoring OSErrors"""
     try:

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -15,6 +15,8 @@ limitations under the License.
 """
 
 """Entry points for goverge."""
+from __future__ import absolute_import
+
 import argparse
 import os
 import shutil

--- a/goverge/main.py
+++ b/goverge/main.py
@@ -22,10 +22,10 @@ from subprocess import PIPE
 from subprocess import Popen
 import sys
 
-from _pkg_meta import version
-from coverage import generate_coverage
-from reports import compile_reports
-from reports import get_coverage_reports
+from ._pkg_meta import version
+from .coverage import generate_coverage
+from .reports import compile_reports
+from .reports import get_coverage_reports
 
 
 def delete_folder(folder):

--- a/goverge/reports.py
+++ b/goverge/reports.py
@@ -13,6 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+from __future__ import print_function
 
 import glob
 import logging
@@ -74,10 +75,10 @@ def compile_reports(reports):
                 else:
                     package_reports[line_parts[0]] = line
 
-            print "{0} was processed in: {1} seconds".format(
-                report, time.clock() - report_start_time)
-    print "Time to process all reports: {0}".format(
-        time.clock() - time_at_beginning)
+            print("{0} was processed in: {1} seconds".format(
+                report, time.clock() - report_start_time))
+    print("Time to process all reports: {0}".format(
+        time.clock() - time_at_beginning))
     write_coverage_to_file(package_reports.values())
 
 
@@ -92,4 +93,4 @@ def write_coverage_to_file(coverage_reports):
     with open("test_coverage.txt", "w") as coverage_file:
         coverage_file.write("mode: set\n")
         coverage_file.write("".join(coverage_reports))
-    print "Coverage file created: test_coverage.txt"
+    print("Coverage file created: test_coverage.txt")


### PR DESCRIPTION
RIS's CI is broken because goverge does not work on python3, and RIS's underlying build container just started shipping python3 instead of python2. goverge doesn't work on python3 for several reasons:

  - sub-module imports without "." prefix
  - print statements (instead of print functions)

python2 supports sub-module imports. With `future` imports, it also supports print statements.

So this change should be compatible with both python2 and python3.