### PR TITLE
CM-539 Release goverge 0.0.24

### DIFF
--- a/goverge/_pkg_meta.py
+++ b/goverge/_pkg_meta.py
@@ -1,2 +1,2 @@
-version_info = (0, 0, 23)
+version_info = (0, 0, 24)
 version = '.'.join(map(str, version_info))


### PR DESCRIPTION

Pull Requests included in release:
* Patch changes:
	* [Add Dependabot to repository for automatic package updates](https://github.com/Workiva/goverge/pull/35)
	* [chore(deps-dev): bump mccabe from 0.3.1 to 0.6.1](https://github.com/Workiva/goverge/pull/36)
	* [chore(deps-dev): bump codecov from 1.4.1 to 2.0.16](https://github.com/Workiva/goverge/pull/37)
	* [chore(deps-dev): bump coverage from 3.7.1 to 5.0.4](https://github.com/Workiva/goverge/pull/40)
	* [chore(deps-dev): bump codecov from 2.0.16 to 2.0.22](https://github.com/Workiva/goverge/pull/41)
	* [chore(deps-dev): bump pyflakes from 0.8.1 to 2.1.1](https://github.com/Workiva/goverge/pull/42)
	* [RED-4337 - Replace Travis CI with GitHub Actions](https://github.com/Workiva/goverge/pull/54)


Requested by: @matthewbelisle-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/goverge/compare/0.0.23...Workiva:release_goverge_0.0.24
Diff Between Last Tag and New Tag: https://github.com/Workiva/goverge/compare/0.0.23...0.0.24

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5984001782710272/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5984001782710272/?pull_number=56&repo_name=Workiva%2Fgoverge)