### PR TITLE
CM-7510 Release goverge 0.0.25

### DIFF
--- a/goverge/_pkg_meta.py
+++ b/goverge/_pkg_meta.py
@@ -1,2 +1,2 @@
-version_info = (0, 0, 24)
+version_info = (0, 0, 25)
 version = '.'.join(map(str, version_info))


### PR DESCRIPTION


Requested by: @matthewbelisle-wf

Diff Between Last Tag and Proposed Release: https://github.com/Workiva/goverge/compare/0.0.24...Workiva:release_goverge_0.0.25
Diff Between Last Tag and New Tag: https://github.com/Workiva/goverge/compare/0.0.24...0.0.25

The logs for the request that created this PR can be found [here](https://w-rmconsole.appspot.com/release/release_event/5984001782710272/logs/)
This pull request can be recreated by clicking [here](https://w-rmconsole.appspot.com/api/v2/rosie/reTriggerReleaseEvents/5984001782710272/?pull_number=57&repo_name=Workiva%2Fgoverge)